### PR TITLE
fix: `ConvexAuthServerState` typing issue

### DIFF
--- a/src/lib/svelte/client.svelte.ts
+++ b/src/lib/svelte/client.svelte.ts
@@ -14,7 +14,7 @@ import type {
 import type { AuthClient } from "./clientType.js";
 import type { TokenStorage } from "./index.svelte.js";
 import type { Value } from "convex/values";
-import type { ConvexAuthServerState } from "$lib/sveltekit/index.js";
+import type { ConvexAuthServerState } from "../sveltekit/index.js";
 
 // Retry after this much time, based on the retry number.
 const RETRY_BACKOFF = [500, 2000]; // In ms

--- a/src/lib/sveltekit/client.svelte.ts
+++ b/src/lib/sveltekit/client.svelte.ts
@@ -10,7 +10,7 @@ import {
 } from "../svelte/client.svelte.js";
 import type { AuthClient } from "../svelte/clientType.js";
 import { ConvexClient, type ConvexClientOptions } from "convex/browser";
-import type { ConvexAuthServerState } from "../svelte/index.svelte";
+import type { ConvexAuthServerState } from "../sveltekit/index.js";
 import { logVerbose } from "./server/utils.js";
 
 /**

--- a/src/lib/sveltekit/server/handlers.ts
+++ b/src/lib/sveltekit/server/handlers.ts
@@ -17,7 +17,7 @@ import { ConvexHttpClient } from "convex/browser";
 import type { ConvexClientOptions } from "convex/browser";
 import type { ConvexAuthHooksOptions } from "./index.js";
 import type { IsAuthenticatedQuery } from "@convex-dev/auth/server";
-import type { ConvexAuthServerState } from "../../svelte/index.svelte";
+import type { ConvexAuthServerState } from "../../sveltekit/index.js";
 
 /**
  * Create server-side handlers for SvelteKit

--- a/src/lib/sveltekit/server/index.ts
+++ b/src/lib/sveltekit/server/index.ts
@@ -11,7 +11,7 @@ import {
   type RouteMatcherFn,
 } from "./routeMatcher.js";
 import type { CookieOptions } from "./cookies.js";
-import type { ConvexAuthServerState } from "../../svelte/index.svelte.js";
+import type { ConvexAuthServerState } from "../../sveltekit/index.js";
 
 /**
  * Options for the createConvexAuthHandlers and createConvexAuthHooks functions


### PR DESCRIPTION
The `ConvexAuthServerState` type was not properly imported in multiple places